### PR TITLE
Correctly locate directory containing JVM shared library in J9 JDKs

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.test.lib;
 
 import java.io.FileNotFoundException;
@@ -358,7 +364,10 @@ public class Platform {
     }
 
     private static String variant() {
-        if (Platform.isServer()) {
+        if (Platform.isServer()
+        || vmName.toLowerCase().contains("openj9")
+        || vmName.toLowerCase().contains("ibm")
+        ) {
             return "server";
         } else if (Platform.isClient()) {
             return "client";


### PR DESCRIPTION
Backport: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/390

Fixes: https://github.com/eclipse-openj9/openj9/issues/14079

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>