### PR TITLE
Use the "default" directory to access J9's libjvm

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -364,7 +364,11 @@ public class Platform {
      * Returns absolute path to directory containing JVM shared library.
      */
     public static Path jvmLibDir() {
-        return libDir().resolve(variant());
+        if (isJ9()) {
+            return libDir().resolve("default");
+	} else {
+            return libDir().resolve(variant());
+        }
     }
 
     private static String variant() {


### PR DESCRIPTION
Workaround for eclipse-openj9/openj9#14397.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>