### PR TITLE
Force properties date tests to use non-conflicting locale

### DIFF
--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -20,6 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -47,7 +53,7 @@ import java.util.TreeSet;
  * @test
  * @summary tests the order in which the Properties.store() method writes out the properties
  * @bug 8231640
- * @run testng PropertiesStoreTest
+ * @run testng/othervm -Duser.language=en -Duser.country=US PropertiesStoreTest
  */
 public class PropertiesStoreTest {
 

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -20,6 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -425,7 +431,8 @@ public class StoreReproducibilityTest {
         System.out.println("Found date comment " + dateComment + " in file " + destFile);
         final Date parsedDate;
         try {
-            Instant instant = Instant.from(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).parse(dateComment));
+            // use root locale instead of system default so there are no format conflicts with parsing the date comment
+            Instant instant = Instant.from(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN).withLocale(Locale.ROOT).parse(dateComment));
             parsedDate = new Date(instant.toEpochMilli());
         } catch (DateTimeParseException pe) {
             throw new RuntimeException("Unexpected date " + dateComment + " in stored properties " + destFile);


### PR DESCRIPTION
The properties date comment is parsed based on the JVM locale settings
which may cause it to fail since the date comment is always written as
if the locale were en_US. Thus, force the tests to use en_US or root
locale.

Signed-off-by: Mike Zhang <mike.h.zhang@ibm.com>

Fixes https://github.com/eclipse-openj9/openj9/issues/14226