### PR TITLE
Updates FileEncodingTest to include correct hardcoded value for AIX

### DIFF
--- a/test/jdk/java/lang/System/FileEncodingTest.java
+++ b/test/jdk/java/lang/System/FileEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8260265
+ * @bug 8260265 8282042
  * @summary Test file.encoding system property
  * @library /test/lib
  * @build jdk.test.lib.process.*
@@ -40,7 +40,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class FileEncodingTest {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
+    private static final String OS_NAME = System.getProperty("os.name");
 
     @DataProvider
     public Object[][] fileEncodingToDefault() {
@@ -56,7 +56,7 @@ public class FileEncodingTest {
     @Test(dataProvider = "fileEncodingToDefault")
     public void testFileEncodingToDefault(String fileEncoding, String expected) throws Exception {
         if (fileEncoding.equals("COMPAT")) {
-            if (IS_WINDOWS) {
+            if (OS_NAME.startsWith("Windows")) {
                 // Only tests on English locales
                 if (Locale.getDefault().getLanguage().equals("en")) {
                     expected = "windows-1252";
@@ -64,6 +64,8 @@ public class FileEncodingTest {
                     System.out.println("Tests only run on Windows with English locales");
                     return;
                 }
+            } else if (OS_NAME.startsWith("AIX")) {
+                expected = "ISO-8859-1";
             } else {
                 expected = "US-ASCII";
             }


### PR DESCRIPTION
Original change merged upstream [here](https://github.com/openjdk/jdk/pull/7525).

As requested, I am creating this PR to move along the upstream fix more quickly. Original discussion in [this issue](https://github.com/eclipse-openj9/openj9/issues/14472#issuecomment-1048047728)

Fixes https://github.com/eclipse-openj9/openj9/issues/14472