### PR TITLE
Stop ignoring warnings in openj9.sharedclasses

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -52,7 +52,6 @@ WARNING_MODULES := \
 	jdk.management \
 	openj9.dtfj \
 	openj9.dtfjview \
-	openj9.sharedclasses \
 	openj9.traceformat \
 	#
 


### PR DESCRIPTION
Depends on eclipse-openj9/openj9#14814.