### PR TITLE
(0.32) Add openssl version 3.0+ support for Linux platforms

### DIFF
--- a/closed/src/java.base/aix/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/aix/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     const char *libname111 = "libcrypto.a(libcrypto64.so.1.1)";
     const char *libname110 = "libcrypto.so.1.1";

--- a/closed/src/java.base/macosx/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/macosx/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     
     const char *libname = "libcrypto.1.1.dylib";

--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,15 +36,20 @@ public class NativeCrypto {
     //ossl_vers:
     // -1 : library load failed
     //  0 : openssl 1.0.x
-    //  1 : openssl 1.1.x
+    //  1 : openssl 1.1.x or newer
     private static final int ossl_ver = AccessController.doPrivileged(
             (PrivilegedAction<Integer>) () -> {
                 int ossl_ver;
+                boolean traceEnabled = Boolean.getBoolean("jdk.nativeCryptoTrace");
+
                 try {
                     System.loadLibrary("jncrypto"); // check for native library
-                    // load OpenSSL crypto library dynamically
-                    ossl_ver = loadCrypto(Boolean.getBoolean("jdk.nativeCryptoTrace"));
-                } catch (UnsatisfiedLinkError e) {
+                    // load OpenSSL crypto library dynamically.
+                    ossl_ver = loadCrypto(traceEnabled);
+                } catch (UnsatisfiedLinkError usle) {
+                    if (traceEnabled) {
+                        System.err.println("UnsatisfiedLinkError: Failure attempting to load jncrypto JNI library");
+                    }
                     // signal load failure
                     ossl_ver = -1;
                 }

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,9 @@
 
 #define OPENSSL_VERSION_1_0 "OpenSSL 1.0."
 #define OPENSSL_VERSION_1_1 "OpenSSL 1.1."
+/* Per new OpenSSL naming convention starting from OpenSSL 3, all major versions are ABI and API compatible. */
+#define OPENSSL_VERSION_3_X "OpenSSL 3."
+
 /* needed for OpenSSL 1.0.2 Thread handling routines */
 #define CRYPTO_LOCK 1
 
@@ -47,12 +50,12 @@
 # include <pthread.h>
 #endif /* defined(WINDOWS) */
 
-/* Header for RSA algorithm using 1.0.2 OpenSSL */
+/* Header for RSA algorithm using 1.0.2 OpenSSL. */
 int OSSL102_RSA_set0_key(RSA *, BIGNUM *, BIGNUM *, BIGNUM *);
 int OSSL102_RSA_set0_factors(RSA *, BIGNUM *, BIGNUM *);
 int OSSL102_RSA_set0_crt_params(RSA *, BIGNUM *, BIGNUM *, BIGNUM *);
 
-/* Define literals from OpenSSL 1.1.x so that it compiles with OpenSSL 1.0.x */
+/* Define literals from OpenSSL 1.1.x so that it compiles with OpenSSL 1.0.x. */
 #ifndef EVP_CTRL_AEAD_GET_TAG
 #define EVP_CTRL_AEAD_GET_TAG EVP_CTRL_GCM_GET_TAG
 #endif
@@ -65,7 +68,7 @@ int OSSL102_RSA_set0_crt_params(RSA *, BIGNUM *, BIGNUM *, BIGNUM *);
 #define EVP_CTRL_AEAD_SET_TAG EVP_CTRL_GCM_SET_TAG
 #endif
 
-/* Type definitions of function pointers */
+/* Type definitions of function pointers. */
 typedef char * OSSL_error_string_n_t(unsigned long, char *, size_t);
 typedef char * OSSL_error_string_t(unsigned long, char *);
 typedef unsigned long OSSL_get_error_t();
@@ -123,7 +126,7 @@ OSSL_error_string_n_t* OSSL_error_string_n;
 OSSL_error_string_t* OSSL_error_string;
 OSSL_get_error_t* OSSL_get_error;
 
-/* Define pointers for OpenSSL 1.0.2 threading routines */
+/* Define pointers for OpenSSL 1.0.2 threading routines. */
 static OSSL_CRYPTO_num_locks_t* OSSL_CRYPTO_num_locks = NULL;
 static OSSL_CRYPTO_THREADID_set_numeric_t* OSSL_CRYPTO_THREADID_set_numeric = NULL;
 static OSSL_OPENSSL_malloc_t* OSSL_OPENSSL_malloc = NULL;
@@ -181,13 +184,13 @@ OSSL_BN_free_t* OSSL_BN_free;
 OSSL_cipher_t* OSSL_chacha20;
 OSSL_cipher_t* OSSL_chacha20_poly1305;
 
-/* Structure for OpenSSL Digest context */
+/* Structure for OpenSSL Digest context. */
 typedef struct OpenSSLMDContext {
     EVP_MD_CTX *ctx;
     const EVP_MD *digestAlg;
 } OpenSSLMDContext;
 
-/* Handle errors from OpenSSL calls */
+/* Handle errors from OpenSSL calls. */
 static void printErrors(void)
 {
     unsigned long errCode = 0;
@@ -219,19 +222,20 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     int ossl_ver;
 
     /* Load OpenSSL Crypto library */
-    crypto_library = load_crypto_library();
+    crypto_library = load_crypto_library(trace);
     if (NULL == crypto_library) {
         if (trace) {
             fprintf(stderr, "Error loading OpenSSL: FAILED TO LOAD OPENSSL CRYPTO LIBRARY\n");
+            fflush(stderr);
         }
         return -1;
     }
 
     /*
-     * Different symbols are used by OpenSSL with 1.0 and 1.1.
-     * The symbol 'OpenSSL_version' is used by OpenSSL 1.1 where as
+     * Different symbols are used by OpenSSL with 1.0 and 1.1 and later.
+     * The symbol 'OpenSSL_version' is used by OpenSSL 1.1 and later where as
      * the symbol "SSLeay_version" is used by OpenSSL 1.0.
-     * Currently only openssl 1.0.x and 1.1.x are supported.
+     * Currently only openssl 1.0.x, 1.1.x and 3.x.x are supported.
      */
     OSSL_version = (OSSL_version_t*)find_crypto_symbol(crypto_library, "OpenSSL_version");
 
@@ -241,6 +245,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         if (NULL == OSSL_version) {
             if (trace) {
                 fprintf(stderr, "Error loading OpenSSL: Error finding the OpenSSL version symbol in the crypto library\n");
+                fflush(stderr);
             }
             unload_crypto_library(crypto_library);
             crypto_library = NULL;
@@ -251,6 +256,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
             if (0 != strncmp(openssl_version, OPENSSL_VERSION_1_0, strlen(OPENSSL_VERSION_1_0))) {
                 if (trace) {
                     fprintf(stderr, "Error loading OpenSSL: Incompatible OpenSSL version found: %s\n", openssl_version);
+                    fflush(stderr);
                 }
                 unload_crypto_library(crypto_library);
                 crypto_library = NULL;
@@ -260,10 +266,13 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         }
     } else {
         openssl_version = (*OSSL_version)(0); /* get OPENSSL_VERSION */
-        /* Ensure the OpenSSL version is "OpenSSL 1.1.x". */
-        if (0 != strncmp(openssl_version, OPENSSL_VERSION_1_1, strlen(OPENSSL_VERSION_1_1))) {
+        /* Ensure the OpenSSL version is "OpenSSL 1.1.x" or "OpenSSL 3.x.x". */
+        if ((0 != strncmp(openssl_version, OPENSSL_VERSION_1_1, strlen(OPENSSL_VERSION_1_1)))
+        && (0 != strncmp(openssl_version, OPENSSL_VERSION_3_X, strlen(OPENSSL_VERSION_3_X)))
+        ) {
             if (trace) {
                 fprintf(stderr, "Error loading OpenSSL: Incompatible OpenSSL version found: %s\n", openssl_version);
+                fflush(stderr);
             }
             unload_crypto_library(crypto_library);
             crypto_library = NULL;

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto_md.h
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto_md.h
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
 #ifndef NATIVECRYPTO_MD_H
 #define NATIVECRYPTO_MD_H
 
-void * load_crypto_library();
+#include <jni.h>
+
+void * load_crypto_library(jboolean traceEnabled);
 void   unload_crypto_library(void *handle);
 void * find_crypto_symbol(void *handle, const char *symname);
 void   get_library_path(void * handle, char * library_path);

--- a/closed/src/java.base/unix/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/unix/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * ===========================================================================
  */
 
+#include <link.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,12 +31,14 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled)
+{
     void * result = NULL;
     size_t i = 0;
     
-    // Library names for OpenSSL 1.1.1, 1.1.0, 1.0.2 and symbolic links
+    // Library names for OpenSSL 3.x, 1.1.1, 1.1.0, 1.0.2 and symbolic links
     static const char * const libNames[] = {
+        "libcrypto.so.3",     // 3.x   library name
         "libcrypto.so.1.1",   // 1.1.x library name
         "libcrypto.so.1.0.0", // 1.0.x library name
         "libcrypto.so.10",    // 1.0.x library name on RHEL
@@ -50,6 +53,12 @@ void * load_crypto_library() {
         result = dlopen (libName,  RTLD_NOW);
     }
 
+    if (traceEnabled && (NULL != result)) {
+        struct link_map *map = NULL;
+        dlinfo(result, RTLD_DI_LINKMAP, &map);
+        fprintf(stderr, "Attempt to load OpenSSL %s\n", map->l_name);
+        fflush(stderr);
+    }
     return result;
 }
 

--- a/closed/src/java.base/windows/native/libjncrypto/NativeCrypto_md.c
+++ b/closed/src/java.base/windows/native/libjncrypto/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 #include "NativeCrypto_md.h"
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     const char *libname = "libcrypto-1_1-x64.dll";
     const char *oldname = "libeay32.dll";

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.Arrays;
@@ -36,7 +42,15 @@ import javax.crypto.spec.GCMParameterSpec;
  */
 public class GCMParameterSpecTest {
 
-    private static final int[] IV_LENGTHS = { 96, 8, 1024 };
+    /*
+     * OpenSSL3 only supports IV lengths up to 16 bytes.
+     * When the IV length is set to be larger than 16 bytes, an error is thrown.
+     * According to the OpenSSL docs([1]), in OpenSSL1.1.1 and older, there is
+     * no error thrown but unpredictable behavior will happen for large IV sizes.
+     *
+     * [1] https://www.openssl.org/docs/man1.1.1/man3/EVP_CIPHER_CTX_block_size.html
+     */
+    private static final int[] IV_LENGTHS = { 96, 8 };
     private static final int[] KEY_LENGTHS = { 128, 192, 256 };
     private static final int[] DATA_LENGTHS = { 0, 128, 1024 };
     private static final int[] AAD_LENGTHS = { 0, 128, 1024 };


### PR DESCRIPTION
Cherry pick of https://github.com/ibmruntimes/openj9-openjdk-jdk18/pull/40 for the 0.32 release.

Signed-off-by: Jinhang Zhang <Jinhang.Zhang@ibm.com>