### PR TITLE
Stop ignoring warnings in jdk.management

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -49,7 +49,6 @@ WARNINGS_AS_ERRORS_OPENJ9 := @WARNINGS_AS_ERRORS_OPENJ9@
 # only ignore warnings in these modules
 WARNING_MODULES := \
 	java.base \
-	jdk.management \
 	openj9.dtfj \
 	openj9.dtfjview \
 	openj9.traceformat \


### PR DESCRIPTION
Depends on eclipse-openj9/openj9#14973.