### PR TITLE
Fix jdk_verctor vm.gz.Z value for jdk18

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -36,10 +36,11 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
 
         Map<String, String> map = new HashMap<>();
         try {
-            map.put("vm.graal.enabled", "false");
             map.put("vm.bits", vmBits());
-            map.put("vm.hasJFR", "false");
             map.put("vm.compiler2.enabled", "false");
+            map.put("vm.gc.Z", "false");
+            map.put("vm.graal.enabled", "false");
+            map.put("vm.hasJFR", "false");
             map.put("vm.jvmti", "true");
             map.put("vm.musl", "false");
         }


### PR DESCRIPTION
- Fix jdk_verctor vm.gz.Z value
- Related Issue: https://github.com/eclipse-openj9/openj9/issues/15064

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>