### PR TITLE
Encapsulate retrieval and display of git SHAs

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -32,31 +32,49 @@ ifeq (,$(BUILD_ID))
   BUILD_ID := 000000
 endif
 
-OPENJDK_SHA := $(shell $(GIT) -C $(TOPDIR) rev-parse --short HEAD)
-ifeq (,$(OPENJDK_SHA))
-  $(error Could not determine OpenJDK SHA)
-endif
+# Auxiliary variables for communication between GetVersion and ShowVersions.
+VersionLabelWidth := 1
+VersionPairs :=
 
-OPENJ9_SHA := $(shell $(GIT) -C $(OPENJ9_TOPDIR) rev-parse --short HEAD)
-ifeq (,$(OPENJ9_SHA))
-  $(error Could not determine OpenJ9 SHA)
-endif
+# GetVersion
+# ----------
+# $1 - repository display name
+# $2 - variable name
+# $3 - root directory of git repository
+# $4 - 'required' for a required repository, anything else for an optional one
+GetVersion = $(eval $(call GetVersionHelper,$(strip $1),$(strip $2),$(strip $3),$(strip $4)))
+define GetVersionHelper
+  $2 := $$(if $(wildcard $3),$$(shell $(GIT) -C $3 rev-parse --short HEAD))
+  ifneq (,$$($2))
+    VersionLabelWidth := $(shell $(ECHO) "$1" | $(AWK) "{ width = length; print (width > $(VersionLabelWidth) ? width : $(VersionLabelWidth)) }")
+    VersionPairs += "$1" "$$($2)"
+  else ifeq ($4,required)
+    $$(error Could not determine $2 for $3)
+  endif
+endef # GetVersionHelper
+
+# ShowVersions
+# ---------
+define ShowVersions
+	@$(PRINTF) "  Source version info:\n"
+	@$(PRINTF) "    %-$(VersionLabelWidth)s - %s\n" $(VersionPairs)
+endef # ShowVersions
+
+$(call GetVersion, openjdk,  OPENJDK_SHA,   $(TOPDIR),           required)
+$(call GetVersion, openj9,   OPENJ9_SHA,    $(OPENJ9_TOPDIR),    required)
+$(call GetVersion, omr,      OPENJ9OMR_SHA, $(OPENJ9OMR_TOPDIR), required)
+$(call GetVersion, openssl,  OPENSSL_SHA,   $(OPENSSL_DIR))
 
 # Find OpenJ9 tag associated with current commit (suppressing stderr in case there is no such tag).
 OPENJ9_TAG := $(shell $(GIT) -C $(OPENJ9_TOPDIR) describe --exact-match HEAD 2>/dev/null)
-ifeq (,$(OPENJ9_TAG))
+ifneq (,$(OPENJ9_TAG))
+  OPENJ9_VERSION_STRING := $(OPENJ9_TAG)
+else
   OPENJ9_BRANCH := $(shell $(GIT) -C $(OPENJ9_TOPDIR) rev-parse --abbrev-ref HEAD)
   ifeq (,$(OPENJ9_BRANCH))
     $(error Could not determine OpenJ9 branch)
   endif
   OPENJ9_VERSION_STRING := $(OPENJ9_BRANCH)-$(OPENJ9_SHA)
-else
-  OPENJ9_VERSION_STRING := $(OPENJ9_TAG)
-endif
-
-OPENJ9OMR_SHA := $(shell $(GIT) -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)
-ifeq (,$(OPENJ9OMR_SHA))
-  $(error Could not determine OMR SHA)
 endif
 
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
@@ -256,8 +274,8 @@ else # OPENJ9_ENABLE_CRIU_SUPPORT
 endif # OPENJ9_ENABLE_CRIU_SUPPORT
 
 # Adjust OpenJDK MethodHandles enablement flags.
-FEATURE_SED_SCRIPT += $(call SedEnable,opt_openjdkMethodhandle)
 FEATURE_SED_SCRIPT += $(call SedDisable,opt_methodHandle)
+FEATURE_SED_SCRIPT += $(call SedEnable,opt_openjdkMethodhandle)
 
 # Disable windows rebase.
 SPEC_SED_SCRIPT += $(call SedDisable,uma_windowsRebase)
@@ -339,9 +357,9 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 
   CMAKE_ARGS := \
 	-C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(patsubst %_cross,%,$(OPENJ9_BUILDSPEC)).cmake \
-	-DCMAKE_TOOLCHAIN_FILE="$(OUTPUTDIR)/toolchain.cmake" \
 	-DBOOT_JDK="$(BOOT_JDK)" \
 	-DBUILD_ID=$(BUILD_ID) \
+	-DCMAKE_TOOLCHAIN_FILE="$(OUTPUTDIR)/toolchain.cmake" \
 	-DJ9VM_OMR_DIR="$(OPENJ9OMR_TOPDIR)" \
 	-DJAVA_SPEC_VERSION=$(VERSION_FEATURE) \
 	-DOMR_DDR=$(OPENJ9_ENABLE_DDR) \
@@ -414,8 +432,8 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
     CMAKE_ARGS += -DJ9VM_OPT_CRIU_SUPPORT=OFF
   endif # OPENJ9_ENABLE_CRIU_SUPPORT
 
-  CMAKE_ARGS += -DJ9VM_OPT_OPENJDK_METHODHANDLE=ON
   CMAKE_ARGS += -DJ9VM_OPT_METHOD_HANDLE=OFF
+  CMAKE_ARGS += -DJ9VM_OPT_OPENJDK_METHODHANDLE=ON
 
   # Propagate configure option '--disable-warnings-as-errors-omr' to OMR.
   ifeq (false,$(WARNINGS_AS_ERRORS_OMR))
@@ -498,10 +516,7 @@ endif # OPENJ9_ENABLE_DDR
 
 build-j9 : run-preprocessors-j9
 	@$(ECHO) "Compiling OpenJ9 in $(OUTPUTDIR)/vm"
-	@$(ECHO) "  Source version info:"
-	@$(ECHO) "    openjdk - $(OPENJDK_SHA)"
-	@$(ECHO) "    openj9  - $(OPENJ9_SHA)"
-	@$(ECHO) "    omr     - $(OPENJ9OMR_SHA)"
+	$(call ShowVersions)
 	+OPENJ9_BUILD=true $(EXPORT_COMPILER_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
 		$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm all
 	@$(ECHO) OpenJ9 compile complete


### PR DESCRIPTION
A back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/455 for Java 18.